### PR TITLE
fix-connectChannelCrash

### DIFF
--- a/KITouch/Flows/ConnectChannelsList/ConnectChannelsListView.swift
+++ b/KITouch/Flows/ConnectChannelsList/ConnectChannelsListView.swift
@@ -26,7 +26,11 @@ struct ConnectChannelsListView: View {
                             ForEach($viewModel.connectChannels) { $channel in
                                 ConnectChannelCard(
                                     channel: $channel,
-                                    onDelete: { viewModel.deleteChannel(channel) }
+                                    onDelete: {
+                                        withAnimation(.smooth) {
+                                            viewModel.deleteChannel(channel)
+                                        }
+                                    }
                                 )
                                 .id(channel.id)
                                 .focused($focusedField, equals: channel)

--- a/KITouch/Flows/ConnectChannelsList/ConnectChannelsListViewModel.swift
+++ b/KITouch/Flows/ConnectChannelsList/ConnectChannelsListViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Foundation
 
 final class ConnectChannelsListViewModel: ObservableObject {
     
@@ -33,8 +34,12 @@ final class ConnectChannelsListViewModel: ObservableObject {
     
     func closeView() {
         guard let viewModel = contactDetalViewModel else { return }
-        connectChannels = viewModel.contact.connectChannels
+        // Сначала закрываем view, потом обновляем данные
         viewModel.isShowingConnectChannelsListView = false
+        // Обновляем данные с задержкой чтобы избежать конфликта с UI
+        DispatchQueue.main.async {
+            self.connectChannels = viewModel.contact.connectChannels
+        }
     }
     
     func deleteChannel(_ channel: ConnectChannel) {


### PR DESCRIPTION
При нажатии кнопки "Отменить" в ConnectChannelsListView иногда происходит краш приложения. Подохреваю, что проблема в том, что UI не успевает отрисоваться. Поменял местами закрытие вью и обновление данных. Обновление данных вынес в главную очередь. Добавил анимацию при удалении канала связи